### PR TITLE
Mod Options Features - Tooltips and Number Formatting

### DIFF
--- a/dami-ModOptions/extensions/ui/menus/pages/color_option.tscn
+++ b/dami-ModOptions/extensions/ui/menus/pages/color_option.tscn
@@ -54,10 +54,10 @@ mouse_default_cursor_shape = 13
 script = ExtResource( 4 )
 
 [node name="ColorPicker" type="ColorPicker" parent="Control"]
-margin_left = 19.0
-margin_top = 50.0
-margin_right = 624.0
-margin_bottom = 742.0
+margin_left = 23.0
+margin_top = 54.0
+margin_right = 628.0
+margin_bottom = 746.0
 rect_scale = Vector2( 0.65, 0.7 )
 mouse_filter = 0
 theme = ExtResource( 1 )

--- a/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.gd
+++ b/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.gd
@@ -11,8 +11,11 @@ onready var color_pickers_container = $ColorPickersContainer
 
 onready var default_button = $DefaultButton
 onready var back_button = $BackButton
+onready var info_popup_container = $CanvasLayer
+onready var info_popup = $CanvasLayer / InfoPopup
 
 var mods_config_interface
+var components_hovered = 0
 
 func _ready():
 	mods_config_interface = get_node("/root/ModLoader/dami-ModOptions/ModsConfigInterface")
@@ -46,6 +49,7 @@ func _init_mod_config_ui(mod_config:Dictionary, mod_name:String):
 	
 	for config_key in mod_config.keys():
 		var config_value = mod_config[config_key]
+		var component = null
 		
 		if config_value is float:
 			
@@ -54,14 +58,29 @@ func _init_mod_config_ui(mod_config:Dictionary, mod_name:String):
 				and not config_key.ends_with("_min")
 				and not config_key.ends_with("_step")
 			):
-				_setup_float_slider(mod_config_values_container, mod_name, mod_config, config_key, config_value)
+				component = _setup_float_slider(mod_config_values_container, mod_name, mod_config, config_key, config_value)
 		
 		elif config_value is bool:
-			_init_bool_button(mod_config_values_container, mod_name, config_key, config_value)
+			component = _init_bool_button(mod_config_values_container, mod_name, config_key, config_value)
 		
 		elif config_value is String and mods_config_interface.is_color_string(config_value):
-			_init_color_picker_button(mod_config_values_container, mod_name, config_key, config_value, color_pickers_container)
+			component = _init_color_picker_button(mod_config_values_container, mod_name, config_key, config_value, color_pickers_container)
+				
+		if component and mod_config.keys().has(config_key + "_tooltip"):
+			component.connect("mouse_entered", self, "on_mouse_entered", [component, mod_config[config_key + "_tooltip"]])
+			component.connect("mouse_exited", self, "on_mouse_exited", [component])
 
+func on_mouse_entered(component, tooltip) -> void:
+	print_debug("entering ", components_hovered)
+	components_hovered += 1
+	info_popup_container.show()
+	info_popup.display(component, Text.text(tooltip))
+	
+func on_mouse_exited(component) -> void:
+	print_debug("exiting ", components_hovered)
+	components_hovered -= 1
+	if components_hovered == 0:
+		info_popup_container.hide()
 
 func _setup_float_slider(parent:Node, mod_name:String, mod_config:Dictionary, config_key:String, config_value:float):
 	var min_value = min(config_value, 0.0)
@@ -86,7 +105,7 @@ func _setup_float_slider(parent:Node, mod_name:String, mod_config:Dictionary, co
 	):
 		step = mod_config[config_key + "_step"]
 	
-	_init_float_slider(parent, config_value, min_value, max_value, step, config_key, mod_name)
+	return _init_float_slider(parent, config_value, min_value, max_value, step, config_key, mod_name)
 
 
 func _init_float_slider(
@@ -106,11 +125,16 @@ func _init_float_slider(
 	new_slider_option._slider.min_value = min_value
 	
 	new_slider_option._label.text = config_key.to_upper()
+	
+	print_debug("new slider value, text: ", new_slider_option._label.text)
+	
 	new_slider_option._value.rect_min_size.x = 140
 	
 	new_slider_option.set_value(current_value)
 	
 	new_slider_option.connect("value_changed", self, "signal_setting_changed", [config_key, mod_name])
+	
+	return new_slider_option
 
 
 func _init_bool_button(parent:Node, mod_name:String, config_key:String, config_value:bool):
@@ -121,6 +145,8 @@ func _init_bool_button(parent:Node, mod_name:String, config_key:String, config_v
 	new_bool_button.pressed = config_value
 	
 	new_bool_button.connect("toggled", self, "signal_setting_changed", [config_key, mod_name])
+	
+	return new_bool_button
 
 
 func _init_color_picker_button(
@@ -139,6 +165,8 @@ func _init_color_picker_button(
 	new_color_option.set_container(container)
 #
 	new_color_option.connect("color_changed", self, "signal_setting_changed", [config_key, mod_name])
+	
+	return new_color_option
 
 
 func signal_setting_changed(value, setting_name:String, mod_name:String):

--- a/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.gd
+++ b/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.gd
@@ -137,15 +137,15 @@ func _init_float_slider(
 	
 	if format != "percent":
 		new_slider_option._slider.disconnect("value_changed", new_slider_option, "_on_HSlider_value_changed")
-		new_slider_option._slider.connect("value_changed", self, "_on_HSlider_value_changed", [new_slider_option])
-		_on_HSlider_value_changed(current_value, new_slider_option)
+		new_slider_option._slider.connect("value_changed", self, "_on_HSlider_value_changed", [new_slider_option, format])
+		_on_HSlider_value_changed(current_value, new_slider_option, format)
 	
 	new_slider_option.connect("value_changed", self, "signal_setting_changed", [config_key, mod_name])
 	
 	return new_slider_option
 
-func _on_HSlider_value_changed(value:float, component)->void :
-	component._value.text = "%.1f X" % value
+func _on_HSlider_value_changed(value:float, component, format)->void :
+	component._value.text = format % value
 	component.emit_signal("value_changed", value)
 	
 func _init_bool_button(parent:Node, mod_name:String, config_key:String, config_value:bool):

--- a/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.tscn
+++ b/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://resources/themes/base_theme.tres" type="Theme" id=1]
 [ext_resource path="res://mods-unpacked/dami-ModOptions/extensions/ui/menus/pages/menu_mods_options.gd" type="Script" id=2]
 [ext_resource path="res://ui/menus/global/my_menu_button.gd" type="Script" id=3]
 [ext_resource path="res://mods-unpacked/dami-ModOptions/extensions/ui/menus/pages/color_pickers_container.gd" type="Script" id=4]
 [ext_resource path="res://resources/fonts/actual/base/font_big_title.tres" type="DynamicFont" id=5]
+[ext_resource path="res://mods-unpacked/dami-ModOptions/tooltip/mod_options_popup.tscn" type="PackedScene" id=6]
 
 [node name="MenuModsOptions" type="VBoxContainer"]
 anchor_right = 1.0
@@ -21,6 +22,12 @@ margin_bottom = 79.0
 custom_fonts/font = ExtResource( 5 )
 text = "MENU_MOD_CONFIG"
 align = 1
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+layer = 10
+visible = false
+
+[node name="InfoPopup" parent="CanvasLayer" instance=ExtResource( 6 )]
 
 [node name="ScrollContainer" type="ScrollContainer" parent="."]
 margin_left = 200.0

--- a/dami-ModOptions/mods_config_interface.gd
+++ b/dami-ModOptions/mods_config_interface.gd
@@ -53,6 +53,9 @@ func flatten_properties(properties:Dictionary) -> Dictionary:
 	
 	for key in properties:
 		var value = properties[key]
+		if value.has("tooltip"):
+			result[key + "_tooltip"] = value.tooltip
+		
 		if value.type == "object":
 			result.merge(flatten_properties(value.properties))
 		elif value.type == "number":
@@ -72,7 +75,7 @@ func flatten_properties(properties:Dictionary) -> Dictionary:
 			if value.has("default"):
 				default_boolean = value.default
 			result[key] = default_boolean
-		
+			
 		elif value.type == "string":
 			if value.has("format") and value.format == "color":
 				var default_color = "#" + Color.white.to_html()

--- a/dami-ModOptions/mods_config_interface.gd
+++ b/dami-ModOptions/mods_config_interface.gd
@@ -69,6 +69,8 @@ func flatten_properties(properties:Dictionary) -> Dictionary:
 				result[key + "_min"] = value.minimum
 			if value.has("multipleOf"):
 				result[key + "_step"] = value.multipleOf
+			if value.has("format"):
+				result[key + "_format"] = value.format
 				
 		elif value.type == "boolean":
 			var default_boolean = false

--- a/dami-ModOptions/tooltip/mod_options_popup.gd
+++ b/dami-ModOptions/tooltip/mod_options_popup.gd
@@ -1,0 +1,17 @@
+extends InfoPopup
+
+func get_pos_from(new_element:Node)->Vector2:
+	var element_pos:Vector2 = new_element.rect_global_position
+	var pos: = element_pos
+	
+	if element_pos.x > Utils.project_width / 2:
+		pos.x = pos.x - _panel.rect_size.x
+	else :
+		pos.x = pos.x + new_element.rect_size.x / 2
+	
+	if element_pos.y > Utils.project_height / 2:
+		pos.y = pos.y - _panel.rect_size.y - DIST
+	else :
+		pos.y = pos.y + new_element.rect_size.y
+	
+	return pos

--- a/dami-ModOptions/tooltip/mod_options_popup.tscn
+++ b/dami-ModOptions/tooltip/mod_options_popup.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://mods-unpacked/dami-ModOptions/tooltip/mod_options_popup.gd" type="Script" id=1]
+[ext_resource path="res://resources/themes/base_theme.tres" type="Theme" id=3]
+[ext_resource path="res://resources/fonts/actual/base/font_small_text.tres" type="DynamicFont" id=4]
+
+[sub_resource type="StyleBoxFlat" id=1]
+bg_color = Color( 0, 0, 0, 1 )
+border_width_left = 5
+border_width_top = 5
+border_width_right = 5
+border_width_bottom = 5
+border_color = Color( 0, 0, 0, 1 )
+border_blend = true
+corner_radius_top_left = 12
+corner_radius_top_right = 12
+corner_radius_bottom_right = 12
+corner_radius_bottom_left = 12
+
+[node name="InfoPopup" type="Control"]
+theme = ExtResource( 3 )
+script = ExtResource( 1 )
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+margin_right = 300.0
+margin_bottom = 64.0
+rect_min_size = Vector2( 400, 0 )
+custom_styles/panel = SubResource( 1 )
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+margin_left = 5.0
+margin_top = 5.0
+margin_right = 395.0
+margin_bottom = 59.0
+custom_constants/margin_right = 15
+custom_constants/margin_top = 15
+custom_constants/margin_left = 15
+custom_constants/margin_bottom = 15
+
+[node name="Description" type="Label" parent="PanelContainer/MarginContainer"]
+margin_left = 15.0
+margin_top = 15.0
+margin_right = 375.0
+margin_bottom = 39.0
+custom_fonts/font = ExtResource( 4 )
+autowrap = true


### PR DESCRIPTION
Adding a "tooltip" parameter to a field will now act as a translation key for a tooltip that will appear when the mod option element is hovered.

Adding a "format" parameter to a "number" field will change the format from a percentage to a number formatted with a number formatting string such as "%02d" for a number filled to 2 digits.